### PR TITLE
2.2.0

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,11 @@
+2.2.0
+-------------------------------------
+- This version introduces backward compatibility for Python 2.7 version by:
+   - replaces @lru_cache native python 3.x-only decorator with pylru external lib
+   - replaces pycurl (which has abandones python 2.7 support since September 2020) with urllib3
+- Adds set_cache_size and get_actual_cache_size (the latter replaces the cache info call from @lru_cache)
+
+
 2.1.0
 -------------------------------------
 - Added lookup_headers(dict) method to WM client. Added tests.

--- a/README
+++ b/README
@@ -27,7 +27,7 @@ to a running instance of the WURFL Microservice product, such as:
 | Python implementation of the WM Client api.
 | Requires:
 
--  Python 3.x
+-  Python 2.7 or 3.x
 -  pip
 -  pycurl module (you can install it with ``pip install pycurl``)
 
@@ -36,7 +36,7 @@ The Example project contains an example of client api usage for a script
 
 .. code:: python
 
-    from wmclient import WmClient
+    from wmclient import WmClient, WmClientError
 
     try:
         client = WmClient.create("http", "localhost", 8080, "")

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This is the Python Client API for accessing the WURFL Microservice. The API is r
 
 Python implementation of the WM Client api.
 Requires:
-- Python 3.x
+- Python 2.7 or 3.x
 - pip
 - pycurl module (you can install it with `pip install pycurl`)
 - requests module (you can install it with `pip install requests`)
@@ -27,7 +27,7 @@ The Example project contains an example of client api usage for a script :
 
 
 ```python
-from wmclient import WmClient
+from wmclient import WmClient, WmClientError
 
 try:
     client = WmClient.create("http", "localhost", 8080, "")
@@ -44,7 +44,7 @@ try:
     client.set_requested_static_capabilities(["brand_name", "model_name"])
     client.set_requested_virtual_capabilities(["is_smartphone", "form_factor"])
     print()
-    print("Detecting device for user-agent: " + ua);
+    print("Detecting device for user-agent: " + ua)
 
     # Perform a device detection calling WM server API
     device = client.lookup_useragent(ua)
@@ -60,7 +60,7 @@ try:
         if capabilities["is_smartphone"] == "true":
             print("This is a smartphone")
             # Iterate over all the device capabilities and print them
-            print("All received capabilities");
+            print("All received capabilities")
             for k in capabilities:
                 print(k + ": " + capabilities[k])
 

--- a/example/example.py
+++ b/example/example.py
@@ -1,4 +1,5 @@
 from wmclient import *
+from requests import Request as HttpRequest
 
 try:
     client = WmClient.create("http", "localhost", 8080, "")
@@ -12,13 +13,24 @@ try:
     ua = "Mozilla/5.0 (Linux; Android 7.1.1; ONEPLUS A5000 Build/NMF26X) AppleWebKit/537.36 (KHTML, like Gecko) " \
          "Chrome/56.0.2924.87 Mobile Safari/537.36 "
 
+    req_headers = {
+        "Accept": "*/*",
+        "Accept-Encoding": "gzip, deflate",
+        "Accept-Language": "en-US,en;q=0.9",
+        "Referer": "http://iporntv.net/",
+        "User-Agent": "Mozilla/5.0 (Linux; U; Android 7.1.1; XT1635-02 Build/NPN26.107; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/85.0.4183.127 Mobile Safari/537.36 OPR/51.0.2254.150807",
+        "X-Forwarded-For": "157.32.186.226",
+        "X-Requested-With": "com.opera.mini.native"
+    }
+    req = HttpRequest('GET', "http://mywebsite.com", headers=req_headers)
+
     client.set_requested_static_capabilities(["brand_name", "model_name"])
     client.set_requested_virtual_capabilities(["is_smartphone", "form_factor"])
     print()
-    print("Detecting device for user-agent: " + ua);
+    print("Detecting device for user-agent: " + ua)
 
     # Perform a device detection calling WM server API
-    device = client.lookup_useragent(ua)
+    device = client.lookup_request(req)
 
     if device.error is not None and len(device.error) > 0:
         print("An error occurred: " + device.error)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README') as f:
 setuptools.setup(
     name='wmclient',
     packages=['wmclient'],
-    version='2.1.0',
+    version='2.2.0',
     license='apache-2.0',
     description='WURFL Microservice client for Python',
     long_description=long_description,
@@ -23,6 +23,7 @@ setuptools.setup(
         'Intended Audience :: Developers',
         'Topic :: Software Development :: Build Tools',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/wmclient/test_wmclient.py
+++ b/wmclient/test_wmclient.py
@@ -611,10 +611,10 @@ class WmClientTest(unittest.TestCase):
         client = createTestClient()
         # perform detection on a dataset without using cache
         uas = createTestUserAgentList()
-        start = time.time_ns()
+        start = time.time()
         for ua in uas:
             client.lookup_useragent(ua)
-        tot_time_elapsed = time.time_ns() - start
+        tot_time_elapsed = time.time() - start
         avg_detection_time = tot_time_elapsed/len(uas)
 
         # now let's add a cache layer and fill it
@@ -624,10 +624,10 @@ class WmClientTest(unittest.TestCase):
         assert(client.get_actual_cache_size()[1] > 0)
 
         # measure cache usage times and compare it with no cache usage times
-        start = time.time_ns()
+        start = time.time()
         for ua in uas:
             client.lookup_useragent(ua)
-        tot_cache_time = time.time_ns() - start
+        tot_cache_time = time.time() - start
         avg_cache_time = tot_cache_time/len(uas)
 
         ua = "ZTE-Z331/1.5.0 NetFront/3.5 QTV5.1 Profile/MIDP-2.1 Configuration/CLDC-1.1"

--- a/wmclient/test_wmclient.py
+++ b/wmclient/test_wmclient.py
@@ -630,6 +630,13 @@ class WmClientTest(unittest.TestCase):
         tot_cache_time = time.time_ns() - start
         avg_cache_time = tot_cache_time/len(uas)
 
+        ua = "ZTE-Z331/1.5.0 NetFront/3.5 QTV5.1 Profile/MIDP-2.1 Configuration/CLDC-1.1"
+        device = client.lookup_useragent(ua)
+        self.assertIsNotNone(device)
+        self.assertIsNotNone(device.capabilities)
+        self.assertEqual("zte_z331_ver1_subuanetfront", device.capabilities["wurfl_id"])
+        self.assertEqual("ZTE Z331", device.capabilities["complete_device_name"])
+
         # cache MUST be at least an order of magnitude faster than detection
         self.assertTrue(avg_detection_time > avg_cache_time * 10)
         self.assertTrue(tot_time_elapsed > tot_cache_time * 10)

--- a/wmclient/test_wmclient.py
+++ b/wmclient/test_wmclient.py
@@ -300,7 +300,7 @@ class WmClientTest(unittest.TestCase):
             client.lookup_device_id("nokia_generic_series40_wrong")
         except WmClientError as e:
             exc = True
-            errmsg = str(e)
+            errmsg = str(e.message)
         self.assertTrue(exc)
         self.assertTrue("device is missing" in errmsg)
         client.destroy()
@@ -314,7 +314,7 @@ class WmClientTest(unittest.TestCase):
             client.lookup_device_id(None)
         except WmClientError as e:
             exc = True
-            errmsg = str(e)
+            errmsg = str(e.message)
         self.assertTrue(exc)
         self.assertTrue("device is missing" in errmsg)
         client.destroy()
@@ -328,7 +328,7 @@ class WmClientTest(unittest.TestCase):
             client.lookup_device_id("")
         except WmClientError as e:
             exc = True
-            errmsg = str(e)
+            errmsg = str(e.message)
         self.assertTrue(exc)
         self.assertTrue("device is missing" in errmsg)
         client.destroy()

--- a/wmclient/wmclient.py
+++ b/wmclient/wmclient.py
@@ -5,7 +5,7 @@ import pylru
 import logging
 import urllib3
 
-__version__ = "2.1.0"
+__version__ = "2.2.0"
 __client_version__ = "wurfl-microservice-python_%s" % __version__
 __default_http_timeout__ = 10
 config_path = ""

--- a/wmclient/wmclient.py
+++ b/wmclient/wmclient.py
@@ -7,7 +7,7 @@ import urllib3
 
 __version__ = "2.1.0"
 __client_version__ = "wurfl-microservice-python_%s" % __version__
-__default_http_timeout__ = 20000
+__default_http_timeout__ = 10
 config_path = ""
 
 logger = logging.getLogger("wurfl-microservice")
@@ -82,7 +82,7 @@ class WmClient:
         return client
 
     def set_http_timeout(self, timeout):
-        """Sets HTTP connection timeout in milliseconds"""
+        """Sets HTTP connection timeout in seconds"""
         if timeout is None or timeout <= 0:
             self.internal_client = urllib3.PoolManager(num_pools=200, maxsize=200, timeout=timeout)
 


### PR DESCRIPTION
- This PR introduces backward compatibility for Python 2.7 version by:
   - replaces **@lru_cache** native python 3.x-only decorator with **pylru** external lib
   - replaces **pycurl** (which has abandones python 2.7 support since September 2020) with **urllib3**
- Adds set_cache_size and get_actual_cache_size (the latter replaces the cache info call from @lru_cache)